### PR TITLE
Fix sftp new session in nonblocking mode

### DIFF
--- a/examples/ssh_X11_client.c
+++ b/examples/ssh_X11_client.c
@@ -453,7 +453,7 @@ connect_local_xsocket(int display_number)
 
 
 static int
-x11_connect_display()
+x11_connect_display(void)
 {
 	int display_number;
 	const char *display = NULL;

--- a/examples/sshnetcat.c
+++ b/examples/sshnetcat.c
@@ -238,7 +238,7 @@ void set_pcap(ssh_session session){
 }
 
 void cleanup_pcap(void);
-void cleanup_pcap(){
+void cleanup_pcap(void){
 	ssh_pcap_file_free(pcap);
 	pcap=NULL;
 }

--- a/include/libssh/sftp.h
+++ b/include/libssh/sftp.h
@@ -217,6 +217,26 @@ struct sftp_statvfs_struct {
 LIBSSH_API sftp_session sftp_new(ssh_session session);
 
 /**
+ * @brief Creates a new sftp session.
+ *
+ * This function does the same thing as sftp_new except that it operates in
+ * non-blocking mode.
+ *
+ * @param session       The ssh session to use.
+ * @param asftp         An address to a sftp session.
+ *
+ * @return              SSH_OK on success,
+ *                      SSH_ERROR if an error occurred,
+ *                      SSH_AGAIN if in nonblocking mode and call has
+ *                      to be done again.
+ *
+ * @see sftp_new()
+ * @see sftp_free()
+ * @see sftp_init()
+ */
+LIBSSH_API int sftp_nonblocking_new(ssh_session session, sftp_session* asftp);
+
+/**
  * @brief Start a new sftp session with an existing channel.
  *
  * @param session       The ssh session to use.
@@ -227,7 +247,6 @@ LIBSSH_API sftp_session sftp_new(ssh_session session);
  * @see sftp_free()
  */
 LIBSSH_API sftp_session sftp_new_channel(ssh_session session, ssh_channel channel);
-
 
 /**
  * @brief Close and deallocate a sftp session.

--- a/src/ABI/libssh-4.5.0.symbols
+++ b/src/ABI/libssh-4.5.0.symbols
@@ -344,6 +344,7 @@ ssh_send_keepalive
 ssh_accept
 channel_write_stderr
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_free
 sftp_init

--- a/src/ABI/libssh-4.6.0.symbols
+++ b/src/ABI/libssh-4.6.0.symbols
@@ -76,6 +76,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.7.0.symbols
+++ b/src/ABI/libssh-4.7.0.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.7.1.symbols
+++ b/src/ABI/libssh-4.7.1.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.7.2.symbols
+++ b/src/ABI/libssh-4.7.2.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.7.3.symbols
+++ b/src/ABI/libssh-4.7.3.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.7.4.symbols
+++ b/src/ABI/libssh-4.7.4.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.8.0.symbols
+++ b/src/ABI/libssh-4.8.0.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.8.1.symbols
+++ b/src/ABI/libssh-4.8.1.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/ABI/libssh-4.9.0.symbols
+++ b/src/ABI/libssh-4.9.0.symbols
@@ -77,6 +77,7 @@ sftp_init
 sftp_lstat
 sftp_mkdir
 sftp_new
+sftp_nonblocking_new
 sftp_new_channel
 sftp_open
 sftp_opendir

--- a/src/init.c
+++ b/src/init.c
@@ -278,7 +278,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL,
  *
  * @see ssh_init()
  */
-bool is_ssh_initialized() {
+bool is_ssh_initialized(void) {
 
     bool is_initialized = false;
 

--- a/src/libssh.map
+++ b/src/libssh.map
@@ -81,6 +81,7 @@ LIBSSH_4_5_0    # Released
         sftp_lstat;
         sftp_mkdir;
         sftp_new;
+        sftp_nonblocking_new;
         sftp_new_channel;
         sftp_open;
         sftp_opendir;

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -109,7 +109,24 @@ static void sftp_ext_free(sftp_ext ext)
     SAFE_FREE(ext);
 }
 
-sftp_session sftp_new(ssh_session session)
+static void sftp_ext_free_session(sftp_session sftp)
+{
+    if (sftp->ext != NULL) {
+        sftp_ext_free(sftp->ext);
+    }
+    if (sftp->channel != NULL) {
+        ssh_channel_free(sftp->channel);
+    }
+    if (sftp->read_packet != NULL) {
+        if (sftp->read_packet->payload != NULL) {
+            SSH_BUFFER_FREE(sftp->read_packet->payload);
+        }
+        SAFE_FREE(sftp->read_packet);
+    }
+    SAFE_FREE(sftp);
+}
+
+static sftp_session sftp_ext_alloc_session(ssh_session session)
 {
     sftp_session sftp;
 
@@ -120,7 +137,6 @@ sftp_session sftp_new(ssh_session session)
     sftp = calloc(1, sizeof(struct sftp_session_struct));
     if (sftp == NULL) {
         ssh_set_error_oom(session);
-
         return NULL;
     }
 
@@ -145,8 +161,24 @@ sftp_session sftp_new(ssh_session session)
     sftp->session = session;
     sftp->channel = ssh_channel_new(session);
     if (sftp->channel == NULL) {
-        ssh_set_error_oom(session);
         goto error;
+    }
+
+    return sftp;
+
+error:
+    sftp_ext_free_session(sftp);
+
+    return NULL;
+}
+
+sftp_session sftp_new(ssh_session session)
+{
+    sftp_session sftp;
+
+    sftp = sftp_ext_alloc_session(session);
+    if (sftp == NULL) {
+        return NULL;
     }
 
     if (ssh_channel_open_session(sftp->channel)) {
@@ -158,21 +190,57 @@ sftp_session sftp_new(ssh_session session)
     }
 
     return sftp;
+
 error:
-    if (sftp->ext != NULL) {
-        sftp_ext_free(sftp->ext);
-    }
-    if (sftp->channel != NULL) {
-        ssh_channel_free(sftp->channel);
-    }
-    if (sftp->read_packet != NULL) {
-        if (sftp->read_packet->payload != NULL) {
-            SSH_BUFFER_FREE(sftp->read_packet->payload);
-        }
-        SAFE_FREE(sftp->read_packet);
-    }
-    SAFE_FREE(sftp);
+    sftp_ext_free_session(sftp);
+
     return NULL;
+}
+
+int sftp_nonblocking_new(ssh_session session, sftp_session* asftp)
+{
+    sftp_session sftp;
+    int err = SSH_NO_ERROR;
+
+    if (asftp == NULL) {
+        return SSH_ERROR;
+    }
+
+    if (*asftp == NULL) {
+        sftp = sftp_ext_alloc_session(session);
+        if (sftp == NULL) {
+            return SSH_ERROR;
+        }
+        *asftp = sftp;
+    } else {
+        sftp = *asftp;
+    }
+
+    if (sftp->channel->state != SSH_CHANNEL_STATE_OPEN) {
+        err = ssh_channel_open_session(sftp->channel);
+        if (err != SSH_OK) {
+            if (err == SSH_AGAIN) {
+                return SSH_AGAIN;
+            }
+            goto error;
+        }
+    }
+
+    err = ssh_channel_request_sftp(sftp->channel);
+    if (err != SSH_OK) {
+        if (err == SSH_AGAIN) {
+            return SSH_AGAIN;
+        }
+        goto error;
+    }
+
+    return err;
+
+error:
+    sftp_ext_free_session(sftp);
+    *asftp = NULL;
+
+    return SSH_ERROR;
 }
 
 sftp_session

--- a/tests/client/torture_sftp_init.c
+++ b/tests/client/torture_sftp_init.c
@@ -45,6 +45,58 @@ static void session_setup(void **state)
     assert_non_null(s->ssh.tsftp);
 }
 
+static void session_setup_nonblocking(void **state)
+{
+    struct torture_state *s = *state;
+    struct passwd *pwd = NULL;
+    ssh_session session = NULL;
+    struct torture_sftp *t;
+    int rc;
+
+    pwd = getpwnam("bob");
+    assert_non_null(pwd);
+
+    rc = setuid(pwd->pw_uid);
+    assert_return_code(rc, errno);
+
+    session = ssh_new();
+    assert_non_null(s->ssh.session);
+    s->ssh.session = session;
+
+    rc = ssh_options_set(session, SSH_OPTIONS_HOST, TORTURE_SSH_SERVER);
+    assert_ssh_return_code(session, rc);
+
+    rc = ssh_options_set(session, SSH_OPTIONS_USER, TORTURE_SSH_USER_ALICE);
+    assert_ssh_return_code(session, rc);
+
+    ssh_set_blocking(session,0);
+    do {
+        rc = ssh_connect(session);
+        assert_ssh_return_code_not_equal(session, rc, SSH_ERROR);
+    } while(rc == SSH_AGAIN);
+
+    do {
+        rc = ssh_userauth_publickey_auto(session, NULL, NULL);
+        assert_ssh_return_code_not_equal(session, rc, SSH_AUTH_ERROR);
+    } while (rc == SSH_AUTH_AGAIN);
+    assert_ssh_return_code_equal(session, rc, SSH_AUTH_SUCCESS);
+
+    t = malloc(sizeof(struct torture_sftp));
+    assert_non_null(t);
+    s->ssh.tsftp = t;
+
+    t->sftp = NULL;
+    do {
+        rc = sftp_nonblocking_new(session, &t->sftp);
+        assert_ssh_return_code_not_equal(session, rc, SSH_ERROR);
+    } while (rc == SSH_AGAIN);
+
+    rc = sftp_init(t->sftp);
+    assert_ssh_return_code_not_equal(session, rc, -1);
+
+    t->testdir = NULL;
+}
+
 static void session_setup_channel(void **state)
 {
     struct torture_state *s = *state;
@@ -76,11 +128,12 @@ static int session_teardown(void **state)
 {
     struct torture_state *s = *state;
 
-    torture_rmdirs(s->ssh.tsftp->testdir);
+    if (s->ssh.tsftp->testdir) {
+        torture_rmdirs(s->ssh.tsftp->testdir);
+    }
     torture_sftp_close(s->ssh.tsftp);
     ssh_disconnect(s->ssh.session);
     ssh_free(s->ssh.session);
-
     return 0;
 }
 
@@ -90,9 +143,12 @@ int torture_run_tests(void) {
         cmocka_unit_test_setup_teardown(session_setup,
                                         NULL,
                                         session_teardown),
+        cmocka_unit_test_setup_teardown(session_setup_nonblocking,
+                                        NULL,
+                                        session_teardown),
         cmocka_unit_test_setup_teardown(session_setup_channel,
                                         NULL,
-                                        session_teardown)
+                                        session_teardown),
     };
 
     ssh_init();


### PR DESCRIPTION
Added a new method for creating sftp sessions in blocking and non-blocking modes.
Keep the old `sftp_new` method for compatibility reasons.
Factorization of the two methods mentioned above.
Resolve this [issue](https://gitlab.com/libssh/libssh-mirror/-/issues/58)

A few minor modifications:
- Fix error at compile time with clang.
- Added an error message when creating a sftp session if it has not been authenticated.