### PR TITLE
sftp: Take timeout option into account in blocking mode

### DIFF
--- a/include/libssh/sftp.h
+++ b/include/libssh/sftp.h
@@ -984,6 +984,9 @@ LIBSSH_API void sftp_handle_remove(sftp_session sftp, void *handle);
 #define SSH_FX_WRITE_PROTECT 12
 /** No media in remote drive */
 #define SSH_FX_NO_MEDIA 13
+/** There is a timeout on a server response in blocking mode */
+#define SSH_FX_TIMEOUT 14
+
 
 /** @} */
 

--- a/src/sftp.c
+++ b/src/sftp.c
@@ -473,6 +473,9 @@ sftp_packet sftp_packet_read(sftp_session sftp)
                 sftp_set_error(sftp, SSH_FX_EOF);
                 goto error;
             }
+            if (ssh_is_blocking(sftp->session)) {
+                goto timeout;
+            }
         } else {
             nread += s;
         }
@@ -497,6 +500,9 @@ sftp_packet sftp_packet_read(sftp_session sftp)
                               "Received EOF while reading sftp packet type");
                 sftp_set_error(sftp, SSH_FX_EOF);
                 goto error;
+            }
+            if (ssh_is_blocking(sftp->session)) {
+                goto timeout;
             }
         }
     } while (nread < 1);
@@ -533,10 +539,18 @@ sftp_packet sftp_packet_read(sftp_session sftp)
                 sftp_set_error(sftp, SSH_FX_EOF);
                 goto error;
             }
+            if (ssh_is_blocking(sftp->session)) {
+                goto timeout;
+            }
         }
     }
 
     return packet;
+timeout:
+    ssh_set_error(sftp->session,
+                  SSH_FATAL,
+                  "No response from server in blocking mode");
+    sftp_set_error(sftp, SSH_FX_TIMEOUT);
 error:
     ssh_buffer_reinit(packet->payload);
     return NULL;

--- a/tests/client/torture_sftp_benchmark.c
+++ b/tests/client/torture_sftp_benchmark.c
@@ -28,6 +28,7 @@ static int session_setup(void **state)
 {
     struct torture_state *s = *state;
     struct passwd *pwd;
+    int timeout = 60; /* in seconds */
     int rc;
 
     pwd = getpwnam("bob");
@@ -42,6 +43,9 @@ static int session_setup(void **state)
                                          TORTURE_SSH_USER_ALICE,
                                          NULL);
     assert_non_null(s->ssh.session);
+
+    rc = ssh_options_set(s->ssh.session, SSH_OPTIONS_TIMEOUT, &timeout); 
+    assert_int_equal(rc, 0);
 
     s->ssh.tsftp = torture_sftp_session(s->ssh.session);
     assert_non_null(s->ssh.tsftp);

--- a/tests/client/torture_sftp_dir.c
+++ b/tests/client/torture_sftp_dir.c
@@ -26,6 +26,7 @@ static int session_setup(void **state)
 {
     struct torture_state *s = *state;
     struct passwd *pwd;
+    int timeout = 60; /* in seconds */
     int rc;
 
     pwd = getpwnam("bob");
@@ -40,6 +41,9 @@ static int session_setup(void **state)
                                          TORTURE_SSH_USER_ALICE,
                                          NULL);
     assert_non_null(s->ssh.session);
+
+    rc = ssh_options_set(s->ssh.session, SSH_OPTIONS_TIMEOUT, &timeout); 
+    assert_int_equal(rc, 0);
 
     s->ssh.tsftp = torture_sftp_session(s->ssh.session);
     assert_non_null(s->ssh.tsftp);

--- a/tests/client/torture_sftp_fsync.c
+++ b/tests/client/torture_sftp_fsync.c
@@ -28,6 +28,7 @@ static int session_setup(void **state)
 {
     struct torture_state *s = *state;
     struct passwd *pwd;
+    int timeout = 60; /* in seconds */
     int rc;
 
     pwd = getpwnam("bob");
@@ -42,6 +43,9 @@ static int session_setup(void **state)
                                          TORTURE_SSH_USER_ALICE,
                                          NULL);
     assert_non_null(s->ssh.session);
+
+    rc = ssh_options_set(s->ssh.session, SSH_OPTIONS_TIMEOUT, &timeout); 
+    assert_int_equal(rc, 0);
 
     s->ssh.tsftp = torture_sftp_session(s->ssh.session);
     assert_non_null(s->ssh.tsftp);

--- a/tests/client/torture_sftp_read.c
+++ b/tests/client/torture_sftp_read.c
@@ -28,6 +28,7 @@ static int session_setup(void **state)
 {
     struct torture_state *s = *state;
     struct passwd *pwd;
+    int timeout = 60; /* in seconds */
     int rc;
 
     pwd = getpwnam("bob");
@@ -42,6 +43,9 @@ static int session_setup(void **state)
                                          TORTURE_SSH_USER_ALICE,
                                          NULL);
     assert_non_null(s->ssh.session);
+
+    rc = ssh_options_set(s->ssh.session, SSH_OPTIONS_TIMEOUT, &timeout); 
+    assert_int_equal(rc, 0);
 
     s->ssh.tsftp = torture_sftp_session(s->ssh.session);
     assert_non_null(s->ssh.tsftp);


### PR DESCRIPTION
In blocking mode, we want to be able to release the client in the case of the server not responding or for other connection-related reasons.

This patch allows you to take the timeout option into account and thus interrupt the reading of the response to an sftp command. 

The developer is then free to either ignore the command or retry a connection with the server.

Resolves this [issue](https://gitlab.com/libssh/libssh-mirror/-/issues/200)